### PR TITLE
NGC-2173: Tokens that fail to be registered are not returned

### DIFF
--- a/app/uk/gov/hmrc/snsclient/aws/sns/SnsConfiguration.scala
+++ b/app/uk/gov/hmrc/snsclient/aws/sns/SnsConfiguration.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.snsclient.aws.sns
 
 import javax.inject.{Inject, Singleton}
 
-import play.api.Configuration
+import play.api.{Configuration, Logger}
 import uk.gov.hmrc.snsclient.aws.AwsConfiguration
 import uk.gov.hmrc.snsclient.config.ConfigKeys._
 import uk.gov.hmrc.snsclient.config.RequiredKeys
@@ -35,12 +35,19 @@ class SnsConfiguration @Inject()(val configuration: Configuration) extends AwsCo
 case class GcmConfiguration(osName: String, apiKey: String, applicationArn: String)
 
 object GcmConfiguration extends RequiredKeys {
-  def from(os: String, gcmConfig: Configuration): Option[GcmConfiguration] =
-    gcmConfig.getConfig(platformConfigurationKey.replace("PLATFORM", os)).map(_ =>
+  def from(os: String, gcmConfig: Configuration): Option[GcmConfiguration] = {
+    val config = gcmConfig.getConfig(platformConfigurationKey.replace("PLATFORM", os)).map(_ =>
       GcmConfiguration(
         os,
         requiredString(apiKey.replace("PLATFORM", os), gcmConfig),
         requiredString(applicationArnKey.replace("PLATFORM", os), gcmConfig)
       )
     )
+
+    val details = config.map(c => s"""applicationArn="${c.applicationArn}", apiKey="${c.apiKey}"""").getOrElse("NOT CONFIGURED!")
+
+    Logger.info(s"sns-client configuration for $os=[$details]")
+
+    config
+  }
 }

--- a/app/uk/gov/hmrc/snsclient/controllers/EndpointsController.scala
+++ b/app/uk/gov/hmrc/snsclient/controllers/EndpointsController.scala
@@ -34,7 +34,7 @@ class EndpointsController @Inject() (sns:SnsApi, metrics:Metrics) extends BaseCo
   val createEndpoints: Action[Seq[Endpoint]] = Action.async(parse.json[Seq[Endpoint]]) { implicit req =>
     sns.createEndpoints(req.body)(defaultContext).map { (statuses: Seq[CreateEndpointStatus]) =>
       metrics.endpointCreationSuccess()
-      Ok(Json.toJson(statuses map(p => p.id-> p.endpointArn) toMap))
+      Ok(Json.toJson(statuses filter(_.endpointArn.isDefined) map(p => p.id-> p.endpointArn) toMap))
     } recover {
       case e =>
         Logger.error(s"Batch creation of endpoints failed ${e.getMessage}")

--- a/test/uk/gov/hmrc/snsclient/controllers/EndpointControllerSpec.scala
+++ b/test/uk/gov/hmrc/snsclient/controllers/EndpointControllerSpec.scala
@@ -83,7 +83,7 @@ class EndpointControllerSpec extends ControllerSpec with DefaultTestData {
     }
 
 
-    "return 200 when 1 of 2 endpoint ARNs are created by SNS" in {
+    "return 200 when 1 of 2 endpoint ARNs are created by SNS and exclude failed tokens" in {
 
       val endpoint = androidEndpoint.copy(registrationToken = "registration-token")
       val endpointStatus = CreateEndpointStatus.failure(endpoint.registrationToken, "Something went horribly wrong")
@@ -94,7 +94,7 @@ class EndpointControllerSpec extends ControllerSpec with DefaultTestData {
       val result = call(controller.createEndpoints, postSnsRequest(url).withJsonBody(toJson(Seq(androidEndpoint, endpoint))))
 
       status(result) mustEqual OK
-      contentAsJson(result) mustEqual toJson(Seq(androidEndpointStatus, endpointStatus) map(p => p.id-> p.endpointArn) toMap)
+      contentAsJson(result) mustEqual toJson(Seq(androidEndpointStatus) map(p => p.id-> p.endpointArn) toMap)
       verify(metrics, times(1)).endpointCreationSuccess()
       verifyNoMoreInteractions(metrics)
     }


### PR DESCRIPTION
Tokens that fail to be registered by AWS are not returned in the createEndpoints() response, which means that they will (eventually) be re-tried